### PR TITLE
Change line-end terminator to UTF-16-CRLF for DSL files.

### DIFF
--- a/lib/dsl_lib.rb
+++ b/lib/dsl_lib.rb
@@ -6,7 +6,7 @@ def save_dsl(dsl_name, header_stuff, dict_content)
 end
 
 def format_header(dict_name, index_lang, contents_lang)
-  "#NAME \"#{dict_name}\"\n#INDEX_LANGUAGE \"#{index_lang}\"\n#CONTENTS_LANGUAGE \"#{contents_lang}\"\n\n"
+  "#NAME \"#{dict_name}\"\r\n#INDEX_LANGUAGE \"#{index_lang}\"\r\n#CONTENTS_LANGUAGE \"#{contents_lang}\"\r\n\r\n"
 end
 
 def get_header(options)

--- a/sentences2dsl/sentences2dsl.rb
+++ b/sentences2dsl/sentences2dsl.rb
@@ -27,11 +27,11 @@ def format_dictionary(sentences_file, options)
     end
     lang1_array.each do |keyword|
       if !json.include?(keyword) && !keyword.match(/^[\s\n]*$/)
-        dict_content << keyword + "\n"
+        dict_content << keyword + "\r\n"
       end
     end
-    dict_content << "\t" + lang1 + "\n"
-    dict_content << "\t" + lang2 + "\n\n"
+    dict_content << "\t" + lang1 + "\r\n"
+    dict_content << "\t" + lang2 + "\r\n\r\n"
   end
   dict_content
 end

--- a/tab2dsl/tab2dsl.rb
+++ b/tab2dsl/tab2dsl.rb
@@ -45,7 +45,7 @@ def format_dictionary(tab_data)
 
       tab1,tab2 = line.chomp.split("\t")
       tab2_format = tab2.gsub(tab1, "[i]~[/i]")
-      dict_entry = tab1 + "\n" + tab2 + "\n\t[m1][b]" + tab1 + "[/b][/m]\n\t[m1]" + tab2_format + "[/m]\n\n"
+      dict_entry = tab1 + "\r\n" + tab2 + "\r\n\t[m1][b]" + tab1 + "[/b][/m]\r\n\t[m1]" + tab2_format + "[/m]\r\n\r\n"
       dict_content << dict_entry
     end
   end

--- a/wiki2dsl/wikidata2dsl.rb
+++ b/wiki2dsl/wikidata2dsl.rb
@@ -37,8 +37,8 @@ tar_extract.each do |entry|
     dict_name = entry.full_name.gsub(/.*\//, "").gsub(/_wiki\.txt/, "")
     index_lang = dict_name.gsub(/\-.*/, "")
     contents_lang = dict_name.gsub(/.*\-/, "")
-    header_stuff = "#NAME \"#{dict_name} Wikidict\"\n#INDEX_LANGUAGE \"#{lang_name[index_lang]}\"\n#CONTENTS_LANGUAGE \"#{lang_name[contents_lang]}\"\n\n"
-    puts "Your dictionary header looks like this:\n\n"
+    header_stuff = "#NAME \"#{dict_name} Wikidict\"\r\n#INDEX_LANGUAGE \"#{lang_name[index_lang]}\"\r\n#CONTENTS_LANGUAGE \"#{lang_name[contents_lang]}\"\r\n\r\n"
+    puts "Your dictionary header looks like this:\r\n\r\n"
     puts header_stuff
     puts "Please wait. Processing dictionary data..."
     dict_content = ""
@@ -49,7 +49,7 @@ tar_extract.each do |entry|
     data.each_line do |line|
       tab1,tab2 = line.chomp.split("\t")
       if !namespace[dir].match(tab2) && !namespace["en"].match(tab2)
-        dict_content << tab1 + "\n" + tab2 + "\n\t[m1]" + tab1 + "[/m]\n\t[m1]" + tab2 + "[/m]\n\n"
+        dict_content << tab1 + "\r\n" + tab2 + "\r\n\t[m1]" + tab1 + "[/m]\r\n\t[m1]" + tab2 + "[/m]\r\n\r\n"
       end
     end
     f << header_stuff

--- a/wiki2dsl/wordlist2dsl.rb
+++ b/wiki2dsl/wordlist2dsl.rb
@@ -42,8 +42,8 @@ tar_extract.each do |entry|
   unless entry.directory? == true
     dict_name = entry.full_name.gsub(/.*\//, "").gsub(/_wiki\.txt/, "")
     index_lang = dict_name.gsub(/\-.*/, "")
-    header_stuff = "#NAME \"#{dict_name} Wiki Wordlist\"\n#INDEX_LANGUAGE \"#{lang_name[index_lang]}\"\n#CONTENTS_LANGUAGE \"#{lang_name[index_lang]}\"\n\n"
-    puts "Your dictionary header looks like this:\n\n"
+    header_stuff = "#NAME \"#{dict_name} Wiki Wordlist\"\r\n#INDEX_LANGUAGE \"#{lang_name[index_lang]}\"\r\n#CONTENTS_LANGUAGE \"#{lang_name[index_lang]}\"\r\n\r\n"
+    puts "Your dictionary header looks like this:\r\n\r\n"
     puts header_stuff
     puts "Please wait. Processing dictionary data..."
     dict_content = ""
@@ -55,7 +55,7 @@ tar_extract.each do |entry|
       tab = line.chomp
       regex = /^[^\s]+:(?!\s)/
       if !regex.match(tab)
-        dict_content << tab + "\n\t[m1]" + tab + "[/m]\n\n"
+        dict_content << tab + "\r\n\t[m1]" + tab + "[/m]\r\n\r\n"
       end
     end
     f << header_stuff

--- a/wikt2dsl/wikt2dsl.rb
+++ b/wikt2dsl/wikt2dsl.rb
@@ -42,7 +42,7 @@ index_lang = first_line.match(re)[1]
 cont_lang = first_line.match(re)[2]
 dict_name = "Wiktionary #{index_lang}-#{cont_lang}"
 
-header_info = "#NAME \"#{dict_name}\"\n#INDEX_LANGUAGE \"#{index_lang}\"\n#CONTENTS_LANGUAGE \"#{cont_lang}\"\n\n"
+header_info = "#NAME \"#{dict_name}\"\r\n#INDEX_LANGUAGE \"#{index_lang}\"\r\n#CONTENTS_LANGUAGE \"#{cont_lang}\"\r\n\r\n"
 
 if options[:dump] != true && options[:test] != true
   puts "The Wiktionary dictionary header looks like this:\n\n"
@@ -89,7 +89,7 @@ source_dict.each do |line|
     # headwords with special characters produce programm exceptions in the regexps below and have to be removed or escaped:
     headword2 = headword.gsub(/[\+\?\.\*\^\$\(\)\[\]\{\}\|\\]/, ".")
     entry = line.gsub(/(\[|\])/, "@@@\\1").gsub(/@@@/, "\\").gsub(/^#{headword2}/, "[b][c darkblue]~[/c][/b]").gsub(/\} \/(.*?)\//, "} [c gray]/\\1/[/c]").gsub(/\{(.*?)\}/, "[p]<\\1>[/p]").gsub(/SEE: (.*) ::/, "\n\tSEE: <<\\1>>").gsub(/ ::\s+(.*)$/, "\n\t[m1]\\1[/m]").gsub(/(\[\/p\] )(\(.*\))/, "\\1[i]\\2[/i]").gsub(/\{|\}/, "")
-    dict_content << headword + "\n\t" + entry + "\n"
+    dict_content << headword + "\r\n\t" + entry + "\r\n"
   end
 end
 

--- a/wikt2dsl/wikt2dsl_twoway.rb
+++ b/wikt2dsl/wikt2dsl_twoway.rb
@@ -42,7 +42,7 @@ index_lang = first_line.match(re)[1]
 cont_lang = first_line.match(re)[2]
 dict_name = "Wiktionary #{index_lang}-#{cont_lang}"
 
-header_info = "#NAME \"#{dict_name}\"\n#INDEX_LANGUAGE \"#{index_lang}\"\n#CONTENTS_LANGUAGE \"#{cont_lang}\"\n\n"
+header_info = "#NAME \"#{dict_name}\"\r\n#INDEX_LANGUAGE \"#{index_lang}\"\r\n#CONTENTS_LANGUAGE \"#{cont_lang}\"\r\n\r\n"
 
 if options[:dump] != true && options[:test] != true
   puts "The Wiktionary dictionary header looks like this:\n\n"
@@ -95,7 +95,7 @@ source_dict.each do |line|
     else
       trans = ""
     end
-    dict_content << headword + "\n" + trans + "\t" + entry + "\n"
+    dict_content << headword + "\r\n" + trans + "\t" + entry + "\r\n"
   end
 end
 

--- a/zip_unzip/rezip_dsl.rb
+++ b/zip_unzip/rezip_dsl.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/ruby
 
-# convert UTF-8 encoded dsl dictionary files to UTF-16
+# convert UTF-8 encoded dsl dictionary files
+# to UTF-16 + CRLF line-end
 # and compress with dictzip to dsl.dz format
 
 def rezip_dictfile(dict)
@@ -10,7 +11,7 @@ def rezip_dictfile(dict)
     dict_content = File.read(dict)
     File.rename(dict, dict + ".bak")
     File.open(dict, 'wt', encoding: 'UTF-16LE') do |dsl|
-      dsl << dict_content
+      dsl << dict_content.gsub("\n", "\r\n")
     end
     `dictzip #{dict}`
     puts "  Processed #{basename}"

--- a/zip_unzip/unzip_dsl.rb
+++ b/zip_unzip/unzip_dsl.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/ruby
 
-# uncompress zipped dsl.dz format dictionary files
-# and convert them to UTF-8 for viewing or editing
+# decompress zipped dsl.dz format dictionary files
+# and convert them to UTF-8 + LF line-end for viewing or editing
 
 def unzip_dictfile(dict)
   ext = File.extname(dict)
@@ -11,7 +11,7 @@ def unzip_dictfile(dict)
   if ext == ".dz"
     `dictunzip #{dict}`
     dict_content = File.open(dsl_loc, "rb:UTF-16LE").read
-    File.open(dsl_loc, "w", encoding: "UTF-8") {|t| t << dict_content }
+    File.open(dsl_loc, "w", encoding: "UTF-8") {|t| t << dict_content.gsub("\r\n", "\n") }
     puts "  Processed #{basename}"
   end
 end


### PR DESCRIPTION
LingvoDSL defines its format with implicit assumption on MS Windows platform. That is because it should be CRLF line end when generating UTF-16LE encoding file.

GoldenDict and other DSL library such as DSL4j try to interpret various combinations of encoding and eol terminators, but it is better to use CRLF to avoid unknown bugs.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>